### PR TITLE
Adding the DPD\\Unit\\ to be PSR-4 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     "files": ["config.php"]
     },
     "autoload-dev": {
-      "psr-0": {
-        "DPD\\": "tests/"
+      "psr-4": {
+        "DPD\\Unit\\": "tests/unit"
       }
     }
 }


### PR DESCRIPTION
# Changed log

- Using the `DPD\Unit` to be namespace for `tests/unit/ServicesTest.php` class with `PSR-4` autoloading because `PSR-0` has been deprecated.